### PR TITLE
feat: add split trigger button with args and webhook modes

### DIFF
--- a/e2e/tests/pipelines.spec.ts
+++ b/e2e/tests/pipelines.spec.ts
@@ -249,6 +249,140 @@ test.describe("Pipeline Management UI", () => {
       });
     });
 
+    test("trigger with args dialog opens, submits, and shows toast", async ({ page, request }) => {
+      const pipelineName = uniqueName("trigger-args-test");
+      await createPipeline(
+        request,
+        pipelineName,
+        `export const pipeline = async () => { console.log("args test"); };`,
+      );
+
+      await page.goto("/pipelines/");
+      await page.getByRole("link", { name: pipelineName }).click();
+
+      // Open the split-button dropdown and click "Trigger with Args…"
+      await page.getByLabel("More trigger options").click();
+      await page.getByRole("menuitem", { name: /trigger with args/i }).click();
+
+      // Dialog should be visible and centered
+      const dialog = page.locator("#trigger-args-dialog");
+      await expect(dialog).toBeVisible();
+
+      // Fill in args (one per line)
+      await page.locator("#trigger-args-input").fill("--env=staging\n--verbose");
+
+      // Submit
+      await page.locator("#trigger-args-submit").click();
+
+      // Should show success toast
+      await expect(page.getByText(/triggered successfully/i)).toBeVisible({
+        timeout: 5000,
+      });
+
+      // Dialog should close
+      await expect(dialog).not.toBeVisible();
+    });
+
+    test("trigger with webhook dialog opens, submits, and shows toast", async ({ page, request }) => {
+      const pipelineName = uniqueName("trigger-webhook-test");
+      await createPipeline(
+        request,
+        pipelineName,
+        `export const pipeline = async () => { console.log("webhook test"); };`,
+      );
+
+      await page.goto("/pipelines/");
+      await page.getByRole("link", { name: pipelineName }).click();
+
+      // Open dropdown and click "Trigger with Webhook…"
+      await page.getByLabel("More trigger options").click();
+      await page.getByRole("menuitem", { name: /trigger with webhook/i }).click();
+
+      // Dialog should be visible
+      const dialog = page.locator("#trigger-webhook-dialog");
+      await expect(dialog).toBeVisible();
+
+      // Fill JSON body
+      await page.locator("#trigger-webhook-body").fill('{"action": "test"}');
+
+      // JSON preview should appear with syntax highlighting
+      const preview = page.locator("#trigger-webhook-preview");
+      await expect(preview).toBeVisible();
+      await expect(preview.locator("code.language-json")).toBeVisible();
+
+      // Submit
+      await page.locator("#trigger-webhook-submit").click();
+
+      // Should show success toast
+      await expect(page.getByText(/triggered successfully/i)).toBeVisible({
+        timeout: 5000,
+      });
+
+      // Dialog should close
+      await expect(dialog).not.toBeVisible();
+    });
+
+    test("trigger args dialog can be cancelled", async ({ page, request }) => {
+      const pipelineName = uniqueName("trigger-cancel-test");
+      await createPipeline(
+        request,
+        pipelineName,
+        `export const pipeline = async () => { console.log("cancel test"); };`,
+      );
+
+      await page.goto("/pipelines/");
+      await page.getByRole("link", { name: pipelineName }).click();
+
+      // Open args dialog
+      await page.getByLabel("More trigger options").click();
+      await page.getByRole("menuitem", { name: /trigger with args/i }).click();
+
+      const dialog = page.locator("#trigger-args-dialog");
+      await expect(dialog).toBeVisible();
+
+      // Click Cancel
+      await dialog.getByRole("button", { name: "Cancel" }).click();
+
+      // Dialog should close
+      await expect(dialog).not.toBeVisible();
+    });
+
+    test("webhook dialog supports adding and removing headers", async ({ page, request }) => {
+      const pipelineName = uniqueName("trigger-headers-test");
+      await createPipeline(
+        request,
+        pipelineName,
+        `export const pipeline = async () => { console.log("headers test"); };`,
+      );
+
+      await page.goto("/pipelines/");
+      await page.getByRole("link", { name: pipelineName }).click();
+
+      // Open webhook dialog
+      await page.getByLabel("More trigger options").click();
+      await page.getByRole("menuitem", { name: /trigger with webhook/i }).click();
+
+      const dialog = page.locator("#trigger-webhook-dialog");
+      await expect(dialog).toBeVisible();
+
+      // Click "+ Add header"
+      await page.locator("#trigger-webhook-add-header").click();
+
+      // Header row should appear
+      const headerRow = page.locator("#trigger-webhook-headers > div").first();
+      await expect(headerRow).toBeVisible();
+
+      // Fill in header key/value
+      await headerRow.locator(".webhook-header-key").fill("X-Custom-Header");
+      await headerRow.locator(".webhook-header-val").fill("test-value");
+
+      // Remove header
+      await headerRow.locator("button").click();
+
+      // Header row should be gone
+      await expect(page.locator("#trigger-webhook-headers > div")).toHaveCount(0);
+    });
+
     test("clicking Tasks link navigates to /runs/:id/tasks", async ({ page, request }) => {
       const pipelineName = uniqueName("tasks-link-test");
       await createPipeline(

--- a/server/api_pipelines_controller.go
+++ b/server/api_pipelines_controller.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/jtarchie/pocketci/orchestra"
+	"github.com/jtarchie/pocketci/runtime/jsapi"
 	"github.com/jtarchie/pocketci/secrets"
 	"github.com/jtarchie/pocketci/server/auth"
 	"github.com/jtarchie/pocketci/storage"
@@ -421,7 +422,22 @@ func (c *APIPipelinesController) Destroy(ctx *echo.Context) error {
 	return ctx.NoContent(http.StatusNoContent)
 }
 
+// triggerRequest is the optional JSON body for POST /api/pipelines/:id/trigger.
+type triggerRequest struct {
+	Mode    string          `json:"mode"`    // "" or "manual" (default), "args", "webhook"
+	Args    []string        `json:"args"`    // for mode="args"
+	Webhook *webhookSimData `json:"webhook"` // for mode="webhook"
+}
+
+// webhookSimData holds simulated webhook payload fields from the UI.
+type webhookSimData struct {
+	Body    string            `json:"body"`
+	Headers map[string]string `json:"headers"`
+	Method  string            `json:"method"`
+}
+
 // Trigger handles POST /api/pipelines/:id/trigger - Trigger pipeline execution.
+// Accepts an optional JSON body to trigger with args or a simulated webhook payload.
 func (c *APIPipelinesController) Trigger(ctx *echo.Context) error {
 	id := ctx.Param("id")
 
@@ -456,7 +472,47 @@ func (c *APIPipelinesController) Trigger(ctx *echo.Context) error {
 		return err
 	}
 
-	run, err := c.execService.TriggerPipeline(ctx.Request().Context(), pipeline)
+	// Parse optional JSON body for trigger mode.
+	var req triggerRequest
+	if ctx.Request().ContentLength > 0 {
+		_ = json.NewDecoder(ctx.Request().Body).Decode(&req)
+	}
+
+	var run *storage.PipelineRun
+
+	switch req.Mode {
+	case "args":
+		run, err = c.execService.TriggerPipeline(ctx.Request().Context(), pipeline, req.Args)
+
+	case "webhook":
+		if !IsFeatureEnabled(FeatureWebhooks, c.allowedFeatures) {
+			return ctx.JSON(http.StatusForbidden, map[string]string{
+				"error": "webhooks feature is not enabled",
+			})
+		}
+
+		method := "POST"
+		if req.Webhook != nil && req.Webhook.Method != "" {
+			method = req.Webhook.Method
+		}
+
+		webhookData := &jsapi.WebhookData{
+			Provider: "manual",
+			Method:   method,
+		}
+		if req.Webhook != nil {
+			webhookData.Body = req.Webhook.Body
+			webhookData.Headers = req.Webhook.Headers
+		}
+
+		responseChan := make(chan *jsapi.HTTPResponse, 1)
+		run, err = c.execService.TriggerWebhookPipeline(ctx.Request().Context(), pipeline, webhookData, responseChan)
+
+	default:
+		// mode="" or "manual" — current behavior
+		run, err = c.execService.TriggerPipeline(ctx.Request().Context(), pipeline, nil)
+	}
+
 	if err != nil {
 		return ctx.JSON(http.StatusInternalServerError, map[string]string{
 			"error": fmt.Sprintf("failed to trigger pipeline: %v", err),

--- a/server/execution.go
+++ b/server/execution.go
@@ -107,8 +107,9 @@ func (s *ExecutionService) MaxInFlight() int {
 
 // TriggerPipeline starts a new pipeline execution asynchronously.
 // It creates a run record, starts a goroutine to execute the pipeline,
-// and returns the run ID immediately.
-func (s *ExecutionService) TriggerPipeline(ctx context.Context, pipeline *storage.Pipeline) (*storage.PipelineRun, error) {
+// and returns the run ID immediately. Optional args are passed through
+// to pipelineContext.args in the runtime.
+func (s *ExecutionService) TriggerPipeline(ctx context.Context, pipeline *storage.Pipeline, args []string) (*storage.PipelineRun, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -126,7 +127,7 @@ func (s *ExecutionService) TriggerPipeline(ctx context.Context, pipeline *storag
 	s.wg.Add(1)
 
 	// Launch execution goroutine
-	go s.executePipeline(pipeline, run, execOptions{requestID: requestID, authProvider: actor.Provider, user: actor.User})
+	go s.executePipeline(pipeline, run, execOptions{args: args, requestID: requestID, authProvider: actor.Provider, user: actor.User})
 
 	return run, nil
 }
@@ -241,6 +242,7 @@ type webhookExecData struct {
 // execOptions holds options for executePipeline.
 type execOptions struct {
 	webhook      *webhookExecData
+	args         []string
 	resume       bool
 	requestID    string
 	authProvider string
@@ -297,6 +299,7 @@ func (s *ExecutionService) executePipeline(pipeline *storage.Pipeline, run *stor
 		RequestID:    opts.requestID,
 		AuthProvider: opts.authProvider,
 		User:         opts.user,
+		Args:         opts.args,
 	}
 
 	// Only pass secrets manager if the secrets feature is enabled

--- a/server/execution_api_test.go
+++ b/server/execution_api_test.go
@@ -1,6 +1,7 @@
 package server_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"log/slog"
@@ -57,6 +58,124 @@ func TestExecutionAPI(t *testing.T) {
 			router.WaitForExecutions()
 			err = client.Close()
 			assert.Expect(err).NotTo(HaveOccurred())
+		})
+
+		t.Run("POST /api/pipelines/:id/trigger with args mode passes args to execution", func(t *testing.T) {
+			t.Parallel()
+			assert := NewGomegaWithT(t)
+
+			buildFile, err := os.CreateTemp(t.TempDir(), "")
+			assert.Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = buildFile.Close() }()
+
+			client, err := storagesqlite.NewSqlite(storagesqlite.Config{Path: buildFile.Name()}, "namespace", slog.Default())
+			assert.Expect(err).NotTo(HaveOccurred())
+
+			pipeline, err := client.SavePipeline(context.Background(), "test-args-pipeline", "export const pipeline = async () => {};", "native", "")
+			assert.Expect(err).NotTo(HaveOccurred())
+
+			router := newStrictSecretRouter(t, client, server.RouterOptions{MaxInFlight: 5})
+			persistPipelineDriverSecret(t, router.ExecutionService().SecretsManager, pipeline.ID, "native")
+
+			body, _ := json.Marshal(map[string]any{
+				"mode": "args",
+				"args": []string{"--env=staging", "--verbose"},
+			})
+			req := httptest.NewRequest(http.MethodPost, "/api/pipelines/"+pipeline.ID+"/trigger", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			assert.Expect(rec.Code).To(Equal(http.StatusAccepted))
+
+			var resp map[string]any
+			err = json.Unmarshal(rec.Body.Bytes(), &resp)
+			assert.Expect(err).NotTo(HaveOccurred())
+			assert.Expect(resp["run_id"]).NotTo(BeEmpty())
+			assert.Expect(resp["status"]).To(Equal("queued"))
+
+			router.WaitForExecutions()
+			err = client.Close()
+			assert.Expect(err).NotTo(HaveOccurred())
+		})
+
+		t.Run("POST /api/pipelines/:id/trigger with webhook mode triggers webhook execution", func(t *testing.T) {
+			t.Parallel()
+			assert := NewGomegaWithT(t)
+
+			buildFile, err := os.CreateTemp(t.TempDir(), "")
+			assert.Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = buildFile.Close() }()
+
+			client, err := storagesqlite.NewSqlite(storagesqlite.Config{Path: buildFile.Name()}, "namespace", slog.Default())
+			assert.Expect(err).NotTo(HaveOccurred())
+
+			pipeline, err := client.SavePipeline(context.Background(), "test-webhook-pipeline", "export const pipeline = async () => {};", "native", "")
+			assert.Expect(err).NotTo(HaveOccurred())
+
+			router := newStrictSecretRouter(t, client, server.RouterOptions{
+				MaxInFlight:     5,
+				AllowedFeatures: "webhooks",
+			})
+			persistPipelineDriverSecret(t, router.ExecutionService().SecretsManager, pipeline.ID, "native")
+
+			body, _ := json.Marshal(map[string]any{
+				"mode": "webhook",
+				"webhook": map[string]any{
+					"method": "POST",
+					"body":   `{"action":"opened"}`,
+				},
+			})
+			req := httptest.NewRequest(http.MethodPost, "/api/pipelines/"+pipeline.ID+"/trigger", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			assert.Expect(rec.Code).To(Equal(http.StatusAccepted))
+
+			var resp map[string]any
+			err = json.Unmarshal(rec.Body.Bytes(), &resp)
+			assert.Expect(err).NotTo(HaveOccurred())
+			assert.Expect(resp["run_id"]).NotTo(BeEmpty())
+
+			router.WaitForExecutions()
+			err = client.Close()
+			assert.Expect(err).NotTo(HaveOccurred())
+		})
+
+		t.Run("POST /api/pipelines/:id/trigger with webhook mode returns 403 when webhooks disabled", func(t *testing.T) {
+			t.Parallel()
+			assert := NewGomegaWithT(t)
+
+			buildFile, err := os.CreateTemp(t.TempDir(), "")
+			assert.Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = buildFile.Close() }()
+
+			client, err := storagesqlite.NewSqlite(storagesqlite.Config{Path: buildFile.Name()}, "namespace", slog.Default())
+			assert.Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = client.Close() }()
+
+			pipeline, err := client.SavePipeline(context.Background(), "test-no-webhook", "export const pipeline = async () => {};", "native", "")
+			assert.Expect(err).NotTo(HaveOccurred())
+
+			router := newStrictSecretRouter(t, client, server.RouterOptions{
+				MaxInFlight:     5,
+				AllowedFeatures: "secrets",
+			})
+
+			body, _ := json.Marshal(map[string]any{
+				"mode": "webhook",
+				"webhook": map[string]any{
+					"method": "POST",
+					"body":   "{}",
+				},
+			})
+			req := httptest.NewRequest(http.MethodPost, "/api/pipelines/"+pipeline.ID+"/trigger", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			assert.Expect(rec.Code).To(Equal(http.StatusForbidden))
 		})
 
 		t.Run("POST /api/pipelines/:id/trigger returns 404 for non-existent pipeline", func(t *testing.T) {

--- a/server/execution_status_test.go
+++ b/server/execution_status_test.go
@@ -48,7 +48,7 @@ export const pipeline = async () => {
 			router := newStrictSecretRouter(t, client, server.RouterOptions{MaxInFlight: 5})
 
 			execService := router.ExecutionService()
-			run, err := execService.TriggerPipeline(context.Background(), pipeline)
+			run, err := execService.TriggerPipeline(context.Background(), pipeline, nil)
 			assert.Expect(err).NotTo(HaveOccurred())
 
 			// Wait for execution to complete
@@ -93,7 +93,7 @@ export const pipeline = async () => {
 			router := newStrictSecretRouter(t, client, server.RouterOptions{MaxInFlight: 5})
 
 			execService := router.ExecutionService()
-			run, err := execService.TriggerPipeline(context.Background(), pipeline)
+			run, err := execService.TriggerPipeline(context.Background(), pipeline, nil)
 			assert.Expect(err).NotTo(HaveOccurred())
 
 			// Wait for execution to complete
@@ -128,7 +128,7 @@ export const pipeline = async () => {
 			router := newStrictSecretRouter(t, client, server.RouterOptions{MaxInFlight: 5})
 
 			execService := router.ExecutionService()
-			run, err := execService.TriggerPipeline(context.Background(), pipeline)
+			run, err := execService.TriggerPipeline(context.Background(), pipeline, nil)
 			assert.Expect(err).NotTo(HaveOccurred())
 
 			execService.Wait()
@@ -161,7 +161,7 @@ export const pipeline = async () => {
 			router := newStrictSecretRouter(t, client, server.RouterOptions{MaxInFlight: 5})
 
 			execService := router.ExecutionService()
-			run, err := execService.TriggerPipeline(context.Background(), pipeline)
+			run, err := execService.TriggerPipeline(context.Background(), pipeline, nil)
 			assert.Expect(err).NotTo(HaveOccurred())
 
 			execService.Wait()
@@ -201,7 +201,7 @@ export const pipeline = async () => {
 			router := newStrictSecretRouter(t, client, server.RouterOptions{MaxInFlight: 5})
 
 			execService := router.ExecutionService()
-			run, err := execService.TriggerPipeline(context.Background(), pipeline)
+			run, err := execService.TriggerPipeline(context.Background(), pipeline, nil)
 			assert.Expect(err).NotTo(HaveOccurred())
 
 			execService.Wait()
@@ -236,7 +236,7 @@ export const pipeline = async () => {
 			router := newStrictSecretRouter(t, client, server.RouterOptions{MaxInFlight: 5})
 
 			execService := router.ExecutionService()
-			run, err := execService.TriggerPipeline(context.Background(), pipeline)
+			run, err := execService.TriggerPipeline(context.Background(), pipeline, nil)
 			assert.Expect(err).NotTo(HaveOccurred())
 
 			execService.Wait()
@@ -269,7 +269,7 @@ export const pipeline = async () => {
 			router := newStrictSecretRouter(t, client, server.RouterOptions{MaxInFlight: 5})
 
 			execService := router.ExecutionService()
-			run, err := execService.TriggerPipeline(context.Background(), pipeline)
+			run, err := execService.TriggerPipeline(context.Background(), pipeline, nil)
 			assert.Expect(err).NotTo(HaveOccurred())
 
 			execService.Wait()
@@ -305,7 +305,7 @@ export const pipeline = async () => {
 			router := newStrictSecretRouter(t, client, server.RouterOptions{MaxInFlight: 5})
 
 			execService := router.ExecutionService()
-			run, err := execService.TriggerPipeline(context.Background(), pipeline)
+			run, err := execService.TriggerPipeline(context.Background(), pipeline, nil)
 			assert.Expect(err).NotTo(HaveOccurred())
 
 			// Pending jobs should not cause failure
@@ -340,7 +340,7 @@ export const pipeline = async () => {
 			router := newStrictSecretRouter(t, client, server.RouterOptions{MaxInFlight: 5})
 
 			execService := router.ExecutionService()
-			run, err := execService.TriggerPipeline(context.Background(), pipeline)
+			run, err := execService.TriggerPipeline(context.Background(), pipeline, nil)
 			assert.Expect(err).NotTo(HaveOccurred())
 
 			execService.Wait()
@@ -374,7 +374,7 @@ export const pipeline = async () => {
 			router := newStrictSecretRouter(t, client, server.RouterOptions{MaxInFlight: 5})
 
 			execService := router.ExecutionService()
-			run, err := execService.TriggerPipeline(context.Background(), pipeline)
+			run, err := execService.TriggerPipeline(context.Background(), pipeline, nil)
 			assert.Expect(err).NotTo(HaveOccurred())
 
 			execService.Wait()

--- a/server/resolve_driver_factory_test.go
+++ b/server/resolve_driver_factory_test.go
@@ -46,7 +46,7 @@ func TestResolveDriverFactory(t *testing.T) {
 		})
 
 		execService := router.ExecutionService()
-		run, err := execService.TriggerPipeline(context.Background(), pipeline)
+		run, err := execService.TriggerPipeline(context.Background(), pipeline, nil)
 		assert.Expect(err).NotTo(HaveOccurred())
 		execService.Wait()
 
@@ -80,7 +80,7 @@ func TestResolveDriverFactory(t *testing.T) {
 		})
 
 		execService := router.ExecutionService()
-		run, err := execService.TriggerPipeline(context.Background(), pipeline)
+		run, err := execService.TriggerPipeline(context.Background(), pipeline, nil)
 		assert.Expect(err).NotTo(HaveOccurred())
 		execService.Wait()
 
@@ -114,7 +114,7 @@ func TestResolveDriverFactory(t *testing.T) {
 		})
 
 		execService := router.ExecutionService()
-		run, err := execService.TriggerPipeline(context.Background(), pipeline)
+		run, err := execService.TriggerPipeline(context.Background(), pipeline, nil)
 		assert.Expect(err).NotTo(HaveOccurred())
 		execService.Wait()
 
@@ -160,7 +160,7 @@ func TestResolveDriverFactory(t *testing.T) {
 		})
 
 		execService := router.ExecutionService()
-		run, err := execService.TriggerPipeline(context.Background(), pipeline)
+		run, err := execService.TriggerPipeline(context.Background(), pipeline, nil)
 		assert.Expect(err).NotTo(HaveOccurred())
 		execService.Wait()
 
@@ -195,7 +195,7 @@ func TestResolveDriverFactory(t *testing.T) {
 		})
 
 		execService := router.ExecutionService()
-		run, err := execService.TriggerPipeline(context.Background(), pipelineA)
+		run, err := execService.TriggerPipeline(context.Background(), pipelineA, nil)
 		assert.Expect(err).NotTo(HaveOccurred())
 		execService.Wait()
 

--- a/server/resume_test.go
+++ b/server/resume_test.go
@@ -45,7 +45,7 @@ export const pipeline = async () => {
 
 			// Trigger the pipeline and wait for it to fail
 			execService := router.ExecutionService()
-			run, err := execService.TriggerPipeline(context.Background(), pipeline)
+			run, err := execService.TriggerPipeline(context.Background(), pipeline, nil)
 			assert.Expect(err).NotTo(HaveOccurred())
 			execService.Wait()
 
@@ -101,7 +101,7 @@ export const pipeline = async () => {
 			router := newStrictSecretRouter(t, client, server.RouterOptions{MaxInFlight: 5})
 
 			execService := router.ExecutionService()
-			run, err := execService.TriggerPipeline(context.Background(), pipeline)
+			run, err := execService.TriggerPipeline(context.Background(), pipeline, nil)
 			assert.Expect(err).NotTo(HaveOccurred())
 			execService.Wait()
 
@@ -406,7 +406,7 @@ export const pipeline = async () => {
 			router := newStrictSecretRouter(t, client, server.RouterOptions{MaxInFlight: 5})
 
 			execService := router.ExecutionService()
-			failRun, err := execService.TriggerPipeline(context.Background(), failPipeline)
+			failRun, err := execService.TriggerPipeline(context.Background(), failPipeline, nil)
 			assert.Expect(err).NotTo(HaveOccurred())
 			execService.Wait()
 

--- a/server/static/src/index.css
+++ b/server/static/src/index.css
@@ -275,6 +275,24 @@ body {
   }
 }
 
+/* Trigger dialog modals */
+dialog.trigger-dialog {
+  margin: auto;
+  position: fixed;
+  inset: 0;
+}
+
+dialog.trigger-dialog::backdrop {
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+@media (prefers-color-scheme: dark) {
+  dialog.trigger-dialog {
+    background-color: #1f2937; /* gray-800 */
+    color: #f9fafb;
+  }
+}
+
 /* Focus visible for better keyboard navigation */
 *:focus-visible {
   outline: 2px solid #3b82f6;

--- a/server/static/src/index.js
+++ b/server/static/src/index.js
@@ -9,11 +9,13 @@ import hljs from "highlight.js/lib/core";
 import yaml from "highlight.js/lib/languages/yaml";
 import typescript from "highlight.js/lib/languages/typescript";
 import javascript from "highlight.js/lib/languages/javascript";
+import json from "highlight.js/lib/languages/json";
 
 // Register languages
 hljs.registerLanguage("yaml", yaml);
 hljs.registerLanguage("typescript", typescript);
 hljs.registerLanguage("javascript", javascript);
+hljs.registerLanguage("json", json);
 
 // Import graph module
 import { initGraph } from "./graph.js";
@@ -137,6 +139,124 @@ document.body.addEventListener("htmx:afterSwap", function () {
   });
 });
 
+// ---- Trigger dialogs (args / webhook) ----
+
+function triggerPipeline(pipelineId, pipelineName, body) {
+  fetch("/api/pipelines/" + pipelineId + "/trigger", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "HX-Request": "true",
+    },
+    body: JSON.stringify(body),
+  })
+    .then(function (resp) {
+      if (!resp.ok) {
+        return resp.text().then(function (t) {
+          throw new Error(t || "Server error " + resp.status);
+        });
+      }
+      showToast(pipelineName + " triggered successfully", "success");
+    })
+    .catch(function (err) {
+      showToast(err.message, "error");
+    });
+}
+
+function initTriggerDialogs() {
+  // Args dialog
+  var argsSubmit = document.getElementById("trigger-args-submit");
+  if (argsSubmit) {
+    argsSubmit.addEventListener("click", function () {
+      var textarea = document.getElementById("trigger-args-input");
+      var args = textarea.value
+        .split("\n")
+        .map(function (l) { return l.trim(); })
+        .filter(function (l) { return l.length > 0; });
+
+      triggerPipeline(argsSubmit.dataset.pipelineId, argsSubmit.dataset.pipelineName, {
+        mode: "args",
+        args: args,
+      });
+
+      textarea.value = "";
+      document.getElementById("trigger-args-dialog").close();
+    });
+  }
+
+  // Webhook dialog - add header button
+  var addHeaderBtn = document.getElementById("trigger-webhook-add-header");
+  if (addHeaderBtn) {
+    addHeaderBtn.addEventListener("click", function () {
+      var container = document.getElementById("trigger-webhook-headers");
+      var row = document.createElement("div");
+      row.className = "flex gap-2 items-center";
+      row.innerHTML =
+        '<input type="text" placeholder="Header name" class="flex-1 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-2 py-1 text-sm dark:text-white webhook-header-key">' +
+        '<input type="text" placeholder="Value" class="flex-1 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-2 py-1 text-sm dark:text-white webhook-header-val">' +
+        '<button type="button" class="text-red-500 hover:text-red-700 text-sm" aria-label="Remove header">&times;</button>';
+      row.querySelector("button").addEventListener("click", function () {
+        row.remove();
+      });
+      container.appendChild(row);
+    });
+  }
+
+  // Webhook dialog - submit
+  var webhookSubmit = document.getElementById("trigger-webhook-submit");
+  if (webhookSubmit) {
+    webhookSubmit.addEventListener("click", function () {
+      var method = document.getElementById("trigger-webhook-method").value;
+      var body = document.getElementById("trigger-webhook-body").value;
+
+      var headers = {};
+      document.querySelectorAll("#trigger-webhook-headers > div").forEach(function (row) {
+        var key = row.querySelector(".webhook-header-key").value.trim();
+        var val = row.querySelector(".webhook-header-val").value.trim();
+        if (key) headers[key] = val;
+      });
+
+      triggerPipeline(webhookSubmit.dataset.pipelineId, webhookSubmit.dataset.pipelineName, {
+        mode: "webhook",
+        webhook: {
+          method: method,
+          body: body,
+          headers: Object.keys(headers).length > 0 ? headers : undefined,
+        },
+      });
+
+      document.getElementById("trigger-webhook-body").value = "";
+      document.getElementById("trigger-webhook-headers").innerHTML = "";
+      document.getElementById("trigger-webhook-dialog").close();
+    });
+  }
+
+  // Webhook body - live JSON syntax highlighting preview
+  var webhookBody = document.getElementById("trigger-webhook-body");
+  var webhookPreview = document.getElementById("trigger-webhook-preview");
+  if (webhookBody && webhookPreview) {
+    var codeEl = webhookPreview.querySelector("code");
+    webhookBody.addEventListener("input", function () {
+      var val = webhookBody.value.trim();
+      if (val) {
+        codeEl.textContent = val;
+        codeEl.removeAttribute("data-highlighted");
+        hljs.highlightElement(codeEl);
+        webhookPreview.classList.remove("hidden");
+      } else {
+        webhookPreview.classList.add("hidden");
+      }
+    });
+  }
+
+  // Close dialogs on backdrop click
+  document.querySelectorAll("dialog.trigger-dialog").forEach(function (dialog) {
+    dialog.addEventListener("click", function (e) {
+      if (e.target === dialog) dialog.close();
+    });
+  });
+}
+
 // Initialize when DOM is ready
 document.addEventListener("DOMContentLoaded", function () {
   // Initialize graph if we're on the graph page
@@ -163,4 +283,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
   // Initialize syntax highlighting
   initSyntaxHighlighting();
+
+  // Initialize trigger dialogs if on pipeline detail page
+  initTriggerDialogs();
 });

--- a/server/stop_run_test.go
+++ b/server/stop_run_test.go
@@ -68,7 +68,7 @@ func TestStopRun(t *testing.T) {
 			router := newStrictSecretRouter(t, client, server.RouterOptions{MaxInFlight: 5})
 
 			execService := router.ExecutionService()
-			run, err := execService.TriggerPipeline(context.Background(), pipeline)
+			run, err := execService.TriggerPipeline(context.Background(), pipeline, nil)
 			assert.Expect(err).NotTo(HaveOccurred())
 
 			// Wait for the pipeline to finish so the run is in a terminal state
@@ -114,7 +114,7 @@ export const pipeline = async () => {
 			router := newStrictSecretRouter(t, client, server.RouterOptions{MaxInFlight: 5})
 
 			execService := router.ExecutionService()
-			run, err := execService.TriggerPipeline(context.Background(), pipeline)
+			run, err := execService.TriggerPipeline(context.Background(), pipeline, nil)
 			assert.Expect(err).NotTo(HaveOccurred())
 
 			// Poll until the run is in running state before stopping it

--- a/server/templates/pipeline_detail.html
+++ b/server/templates/pipeline_detail.html
@@ -47,26 +47,57 @@
         </div>
         <div
           class="flex w-full flex-col gap-3 sm:w-auto sm:flex-row sm:items-center">
-          <button
-            id="trigger-btn"
-            class="trigger-btn w-full px-6 py-3 bg-green-600 hover:bg-green-700 text-white rounded-lg font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 disabled:opacity-50 disabled:cursor-not-allowed sm:w-auto"
-            hx-post="/api/pipelines/{{ .Pipeline.ID }}/trigger"
-            hx-swap="none"
-            data-pipeline-name="{{ .Pipeline.Name }}"
-            aria-label="Trigger"
-            title="Trigger pipeline execution">
-            <span class="btn-text">Trigger</span>
-            <span class="htmx-indicator">
-              <svg class="animate-spin h-5 w-5 inline"
-                xmlns="http://www.w3.org/2000/svg" fill="none"
-                viewBox="0 0 24 24">
-                <circle class="opacity-25" cx="12" cy="12" r="10"
-                  stroke="currentColor" stroke-width="4"></circle>
-                <path class="opacity-75" fill="currentColor"
-                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-              </svg>
-            </span>
-          </button>
+          <!-- Split trigger button -->
+          <div class="flex w-full sm:w-auto" role="group" aria-label="Trigger actions">
+            <button
+              id="trigger-btn"
+              class="trigger-btn flex-1 sm:flex-initial px-6 py-3 bg-green-600 hover:bg-green-700 text-white rounded-l-lg font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 disabled:opacity-50 disabled:cursor-not-allowed"
+              hx-post="/api/pipelines/{{ .Pipeline.ID }}/trigger"
+              hx-swap="none"
+              data-pipeline-name="{{ .Pipeline.Name }}"
+              aria-label="Trigger"
+              title="Trigger pipeline execution">
+              <span class="btn-text">Trigger</span>
+              <span class="htmx-indicator">
+                <svg class="animate-spin h-5 w-5 inline"
+                  xmlns="http://www.w3.org/2000/svg" fill="none"
+                  viewBox="0 0 24 24">
+                  <circle class="opacity-25" cx="12" cy="12" r="10"
+                    stroke="currentColor" stroke-width="4"></circle>
+                  <path class="opacity-75" fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                </svg>
+              </span>
+            </button>
+            <details class="relative" id="trigger-dropdown">
+              <summary
+                class="flex items-center justify-center h-full px-3 py-3 bg-green-700 hover:bg-green-800 text-white rounded-r-lg cursor-pointer transition-colors focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 list-none [&::-webkit-details-marker]:hidden border-l border-green-800"
+                aria-label="More trigger options"
+                aria-haspopup="true">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                </svg>
+              </summary>
+              <div
+                class="absolute right-0 top-full mt-1 w-56 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg z-50 py-1"
+                role="menu">
+                <button
+                  type="button"
+                  onclick="document.getElementById('trigger-args-dialog').showModal(); this.closest('details').removeAttribute('open');"
+                  class="block w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:bg-gray-100 dark:focus:bg-gray-700"
+                  role="menuitem">
+                  Trigger with Args&hellip;
+                </button>
+                <button
+                  type="button"
+                  onclick="document.getElementById('trigger-webhook-dialog').showModal(); this.closest('details').removeAttribute('open');"
+                  class="block w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:bg-gray-100 dark:focus:bg-gray-700"
+                  role="menuitem">
+                  Trigger with Webhook&hellip;
+                </button>
+              </div>
+            </details>
+          </div>
           <details class="relative sm:w-auto">
             <summary
               class="flex items-center justify-center w-full sm:w-auto px-4 py-3 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 rounded-lg cursor-pointer transition-colors focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2 dark:focus:ring-offset-gray-800 list-none [&::-webkit-details-marker]:hidden"
@@ -105,4 +136,92 @@
 
 {{ template "footer" }}
 {{ template "toast-container" }}
+
+<!-- Trigger with Args dialog -->
+<dialog id="trigger-args-dialog"
+  class="trigger-dialog rounded-lg shadow-xl p-0 w-full max-w-lg backdrop:bg-black/50 dark:bg-gray-800 dark:text-white"
+  aria-labelledby="trigger-args-title">
+  <form method="dialog" class="p-6">
+    <h2 id="trigger-args-title" class="text-lg font-semibold mb-4">Trigger with Arguments</h2>
+    <label for="trigger-args-input" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+      Arguments (one per line)
+    </label>
+    <textarea
+      id="trigger-args-input"
+      rows="6"
+      placeholder="--env=staging&#10;--verbose&#10;my-target"
+      class="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-green-500 dark:text-white"></textarea>
+    <div class="flex justify-end gap-3 mt-4">
+      <button type="button"
+        onclick="this.closest('dialog').close()"
+        class="px-4 py-2 text-sm text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-lg transition-colors">
+        Cancel
+      </button>
+      <button type="button"
+        id="trigger-args-submit"
+        data-pipeline-id="{{ .Pipeline.ID }}"
+        data-pipeline-name="{{ .Pipeline.Name }}"
+        class="px-4 py-2 text-sm text-white bg-green-600 hover:bg-green-700 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-green-500">
+        Trigger
+      </button>
+    </div>
+  </form>
+</dialog>
+
+<!-- Trigger with Webhook dialog -->
+<dialog id="trigger-webhook-dialog"
+  class="trigger-dialog rounded-lg shadow-xl p-0 w-full max-w-lg backdrop:bg-black/50 dark:bg-gray-800 dark:text-white"
+  aria-labelledby="trigger-webhook-title">
+  <form method="dialog" class="p-6">
+    <h2 id="trigger-webhook-title" class="text-lg font-semibold mb-4">Trigger with Webhook Payload</h2>
+
+    <label for="trigger-webhook-method" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+      Method
+    </label>
+    <select id="trigger-webhook-method"
+      class="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-500 dark:text-white mb-4">
+      <option value="POST" selected>POST</option>
+      <option value="GET">GET</option>
+      <option value="PUT">PUT</option>
+      <option value="PATCH">PATCH</option>
+      <option value="DELETE">DELETE</option>
+    </select>
+
+    <div class="mb-4">
+      <div class="flex items-center justify-between mb-1">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Headers</label>
+        <button type="button" id="trigger-webhook-add-header"
+          class="text-xs text-green-600 dark:text-green-400 hover:underline">+ Add header</button>
+      </div>
+      <div id="trigger-webhook-headers" class="space-y-2"></div>
+    </div>
+
+    <label for="trigger-webhook-body" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+      JSON Body
+    </label>
+    <textarea
+      id="trigger-webhook-body"
+      rows="10"
+      placeholder='{"action": "opened", "repository": {"full_name": "owner/repo"}}'
+      class="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-green-500 dark:text-white"></textarea>
+    <pre id="trigger-webhook-preview"
+      class="hidden mt-2 rounded-lg border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-900 p-3 text-sm font-mono overflow-auto max-h-48"><code class="language-json"></code></pre>
+
+    <div class="flex justify-end gap-3 mt-4">
+      <button type="button"
+        onclick="this.closest('dialog').close()"
+        class="px-4 py-2 text-sm text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-lg transition-colors">
+        Cancel
+      </button>
+      <button type="button"
+        id="trigger-webhook-submit"
+        data-pipeline-id="{{ .Pipeline.ID }}"
+        data-pipeline-name="{{ .Pipeline.Name }}"
+        class="px-4 py-2 text-sm text-white bg-green-600 hover:bg-green-700 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-green-500">
+        Trigger
+      </button>
+    </div>
+  </form>
+</dialog>
+
 {{ template "end" }}

--- a/server/web_runs_controller_test.go
+++ b/server/web_runs_controller_test.go
@@ -44,7 +44,7 @@ export const pipeline = async () => {
 	router := newStrictSecretRouter(t, client, server.RouterOptions{MaxInFlight: 5})
 	execService := router.ExecutionService()
 
-	run, err := execService.TriggerPipeline(context.Background(), pipeline)
+	run, err := execService.TriggerPipeline(context.Background(), pipeline, nil)
 	assert.Expect(err).NotTo(HaveOccurred())
 	execService.Wait()
 


### PR DESCRIPTION
## Summary

- Adds a split-button dropdown on the pipeline detail page with three trigger modes: manual (default), args, and webhook
- Extends `POST /api/pipelines/:id/trigger` to accept an optional JSON body with `mode`, `args`, and `webhook` fields
- Args mode passes arguments through to `pipelineContext.args` in the runtime
- Webhook mode constructs `WebhookData` with provider `"manual"` and triggers via `TriggerWebhookPipeline`
- Adds dialog modals for args (one-per-line textarea) and webhook (method select, dynamic headers, JSON body with live syntax-highlighted preview)
- Dialogs are centered in viewport with dark mode support

## Test plan

- [x] 3 new Go unit tests for args trigger, webhook trigger, and webhook-disabled 403
- [x] 4 new Playwright e2e tests for dialog open/submit/cancel and header add/remove
- [x] All 27 e2e tests pass
- [x] All server unit tests pass
- [ ] Manual browser test: verify dialog centering, JSON preview highlighting, and all three trigger modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)